### PR TITLE
fixed typo, from 'types' -> 'type'

### DIFF
--- a/src/xdo.nim
+++ b/src/xdo.nim
@@ -28,7 +28,7 @@ const
     "191":"/","192":"`","219":"[","220":"\\","221":"]","222":"'"
   }.toTable  ## Statically compiled JSON that maps KeyCodes integers Versus Keys strings.
 
-types
+type
   Actions*         = enum             ## All Actions.
     close          = "close"           ## Close the window.
     kill           = "kill"            ## Kill the client.


### PR DESCRIPTION
Hope this fixes #1 

I now get some other kind of error:

```
➜ nim doc src/xdo.nim
#... hints and all that ... then the prog runs
0.5.7
0x04800001
15311
(output: "", exitCode: 0)
(output: "", exitCode: 0)
(output: "", exitCode: 0)
(output: "", exitCode: 139)
(output: "", exitCode: 0)
(output: "", exitCode: 139)
(output: "", exitCode: 0)
(output: "", exitCode: 0)
 ^[[17~^[[H^[OR50^[OR^[[20~^[[18~^[OQxdo_examples1.nim(22)    xdo_examples1
xdo.nim(544)             xdo_type_current_dir
xdo.nim(533)             xdo_type
tables.nim(151)          []
Error: unhandled exception: key not found: P [KeyError]
Error: execution of an external program failed: '/home/tzekid/.cache/nim/xdo_d/runnableExamples/xdo_examples1 '
[Examples] failed: see /home/tzekid/.cache/nim/xdo_d/runnableExamples/xdo_examples1.nim
```

Time to create some xdo examples then? :smile: